### PR TITLE
refactor: be more permissive in function inputs

### DIFF
--- a/examples/inverse_public_ws_api_client.rs
+++ b/examples/inverse_public_ws_api_client.rs
@@ -5,7 +5,7 @@ fn main() {
 
     let mut client = PublicWebSocketApiClient::new("wss://stream.bybit.com/realtime");
 
-    let symbols = vec!["BTCUSD".to_owned(), "ETHUSDU22".to_owned()];
+    let symbols = vec!["BTCUSD", "ETHUSDU22"];
     client.subscribe_order_book_l2_25(&symbols);
     client.subscribe_order_book_l2_200(&symbols);
     client.subscribe_trade(&symbols);

--- a/examples/linear_public_ws_api_client.rs
+++ b/examples/linear_public_ws_api_client.rs
@@ -5,7 +5,7 @@ fn main() {
 
     let mut client = PublicWebSocketApiClient::new("wss://stream.bybit.com/realtime_public");
 
-    let symbols = vec!["BTCUSDT".to_owned(), "ETHUSDT".to_owned()];
+    let symbols = vec!["BTCUSDT", "ETHUSDT"];
     client.subscribe_order_book_l2_25(&symbols);
     client.subscribe_order_book_l2_200(&symbols);
     client.subscribe_trade(&symbols);

--- a/src/inverse/ws.rs
+++ b/src/inverse/ws.rs
@@ -451,32 +451,32 @@ impl PublicWebSocketApiClient {
         };
     }
 
-    pub fn subscribe_order_book_l2_25(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_order_book_l2_25<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("orderBookL2_25", symbols);
     }
 
-    pub fn subscribe_order_book_l2_200(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_order_book_l2_200<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("orderBook_200.100ms", symbols);
     }
 
-    pub fn subscribe_trade(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_trade<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("trade", symbols);
     }
 
-    pub fn subscribe_insurance(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_insurance<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("insurance", symbols);
     }
 
-    pub fn subscribe_instrument_info(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_instrument_info<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("instrument_info.100ms", symbols);
     }
 
-    pub fn subscribe_kline(&mut self, symbols: &Vec<String>, interval: &str) {
+    pub fn subscribe_kline<S: AsRef<str>>(&mut self, symbols: &[S], interval: &str) {
         let topic = format!("klineV2.{}", interval);
         self.subscribe(&topic, symbols);
     }
 
-    pub fn subscribe_liquidation(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_liquidation<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("liquidation", symbols);
     }
 
@@ -519,10 +519,13 @@ impl PublicWebSocketApiClient {
         Ok(())
     }
 
-    fn subscribe(&mut self, topic: &str, symbols: &Vec<String>) {
+    fn subscribe<S>(&mut self, topic: &str, symbols: &[S])
+    where
+        S: AsRef<str>,
+    {
         let args = symbols
             .iter()
-            .map(|symbol| format!("{}.{}", topic, symbol))
+            .map(|symbol| format!("{}.{}", topic, symbol.as_ref()))
             .collect();
         let subscription = Subscription {
             op: "subscribe".into(),

--- a/src/linear/ws.rs
+++ b/src/linear/ws.rs
@@ -283,28 +283,28 @@ impl PublicWebSocketApiClient {
         };
     }
 
-    pub fn subscribe_order_book_l2_25(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_order_book_l2_25<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("orderBookL2_25", symbols);
     }
 
-    pub fn subscribe_order_book_l2_200(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_order_book_l2_200<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("orderBook_200.100ms", symbols);
     }
 
-    pub fn subscribe_trade(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_trade<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("trade", symbols);
     }
 
-    pub fn subscribe_instrument_info(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_instrument_info<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("instrument_info.100ms", symbols);
     }
 
-    pub fn subscribe_kline(&mut self, symbols: &Vec<String>, interval: &str) {
+    pub fn subscribe_kline<S: AsRef<str>>(&mut self, symbols: &[S], interval: &str) {
         let topic = format!("candle.{}", interval);
         self.subscribe(&topic, symbols);
     }
 
-    pub fn subscribe_liquidation(&mut self, symbols: &Vec<String>) {
+    pub fn subscribe_liquidation<S: AsRef<str>>(&mut self, symbols: &[S]) {
         self.subscribe("liquidation", symbols);
     }
 
@@ -344,10 +344,10 @@ impl PublicWebSocketApiClient {
         Ok(())
     }
 
-    fn subscribe(&mut self, topic: &str, symbols: &Vec<String>) {
+    fn subscribe<S: AsRef<str>>(&mut self, topic: &str, symbols: &[S]) {
         let args = symbols
             .iter()
-            .map(|symbol| format!("{}.{}", topic, symbol))
+            .map(|symbol| format!("{}.{}", topic, symbol.as_ref()))
             .collect();
         let subscription = Subscription {
             op: "subscribe".into(),

--- a/src/spot/ws.rs
+++ b/src/spot/ws.rs
@@ -389,7 +389,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: "trade".into(),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -400,7 +400,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: "realtimes".into(),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -411,7 +411,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: format!("kline_{}", kline_type),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -422,7 +422,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: "depth".into(),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -438,7 +438,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: "mergedDepth".into(),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: MergedDepthParams { binary, dump_scale },
         };
         self.subscriptions
@@ -449,7 +449,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: "diffDepth".into(),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -460,7 +460,7 @@ impl PublicWebSocketApiClient {
         let subscription = Subscription {
             topic: "lt".into(),
             event: "sub".into(),
-            symbol: symbol.as_ref().to_string(),
+            symbol: symbol.as_ref().to_owned(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -551,7 +551,7 @@ impl PublicV2WebSocketApiClient {
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.as_ref().to_string(),
+                symbol: symbol.as_ref().to_owned(),
             },
         };
         self.subscriptions
@@ -564,7 +564,7 @@ impl PublicV2WebSocketApiClient {
             event: "sub".into(),
             params: KlineParamsV2 {
                 binary,
-                symbol: symbol.as_ref().to_string(),
+                symbol: symbol.as_ref().to_owned(),
                 kline_type: kline_type.to_string(),
             },
         };
@@ -578,7 +578,7 @@ impl PublicV2WebSocketApiClient {
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.as_ref().to_string(),
+                symbol: symbol.as_ref().to_owned(),
             },
         };
         self.subscriptions
@@ -591,7 +591,7 @@ impl PublicV2WebSocketApiClient {
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.as_ref().to_string(),
+                symbol: symbol.as_ref().to_owned(),
             },
         };
         self.subscriptions
@@ -604,7 +604,7 @@ impl PublicV2WebSocketApiClient {
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.as_ref().to_string(),
+                symbol: symbol.as_ref().to_owned(),
             },
         };
         self.subscriptions

--- a/src/spot/ws.rs
+++ b/src/spot/ws.rs
@@ -385,77 +385,82 @@ impl PublicWebSocketApiClient {
         };
     }
 
-    pub fn subscribe_trade(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_trade<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = Subscription {
             topic: "trade".into(),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: CommonParams { binary },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_realtimes(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_realtimes<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = Subscription {
             topic: "realtimes".into(),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: CommonParams { binary },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_kline(&mut self, symbol: &str, kline_type: &str, binary: bool) {
+    pub fn subscribe_kline<S: AsRef<str>>(&mut self, symbol: S, kline_type: &str, binary: bool) {
         let subscription = Subscription {
             topic: format!("kline_{}", kline_type),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: CommonParams { binary },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_depth(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_depth<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = Subscription {
             topic: "depth".into(),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: CommonParams { binary },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_merged_depth(&mut self, symbol: &str, binary: bool, dump_scale: usize) {
+    pub fn subscribe_merged_depth<S: AsRef<str>>(
+        &mut self,
+        symbol: S,
+        binary: bool,
+        dump_scale: usize,
+    ) {
         let subscription = Subscription {
             topic: "mergedDepth".into(),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: MergedDepthParams { binary, dump_scale },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_diff_depth(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_diff_depth<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = Subscription {
             topic: "diffDepth".into(),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: CommonParams { binary },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_lt(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_lt<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = Subscription {
             topic: "lt".into(),
             event: "sub".into(),
-            symbol: symbol.to_string(),
+            symbol: symbol.as_ref().to_string(),
             params: CommonParams { binary },
         };
         self.subscriptions
@@ -540,26 +545,26 @@ impl PublicV2WebSocketApiClient {
         };
     }
 
-    pub fn subscribe_depth(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_depth<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = SubscriptionV2 {
             topic: "depth".into(),
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.to_string(),
+                symbol: symbol.as_ref().to_string(),
             },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_kline(&mut self, symbol: &str, binary: bool, kline_type: &str) {
+    pub fn subscribe_kline<S: AsRef<str>>(&mut self, symbol: S, binary: bool, kline_type: &str) {
         let subscription = SubscriptionV2 {
             topic: "kline".into(),
             event: "sub".into(),
             params: KlineParamsV2 {
                 binary,
-                symbol: symbol.to_string(),
+                symbol: symbol.as_ref().to_string(),
                 kline_type: kline_type.to_string(),
             },
         };
@@ -567,39 +572,39 @@ impl PublicV2WebSocketApiClient {
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_trade(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_trade<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = SubscriptionV2 {
             topic: "trade".into(),
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.to_string(),
+                symbol: symbol.as_ref().to_string(),
             },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_book_ticker(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_book_ticker<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = SubscriptionV2 {
             topic: "bookTicker".into(),
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.to_string(),
+                symbol: symbol.as_ref().to_string(),
             },
         };
         self.subscriptions
             .push(serde_json::to_string(&subscription).unwrap());
     }
 
-    pub fn subscribe_realtimes(&mut self, symbol: &str, binary: bool) {
+    pub fn subscribe_realtimes<S: AsRef<str>>(&mut self, symbol: S, binary: bool) {
         let subscription = SubscriptionV2 {
             topic: "realtimes".into(),
             event: "sub".into(),
             params: CommonParamsV2 {
                 binary,
-                symbol: symbol.to_string(),
+                symbol: symbol.as_ref().to_string(),
             },
         };
         self.subscriptions


### PR DESCRIPTION
Do not require the caller to pass owned strings, since a reference
will suffice.