### PR TITLE
RFC: refactoring the inverse websocket for ergonomic use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ url = "2.1.0"
 ring = "0.16.20"
 hex = "0.4"
 log = "0.4"
+env_logger = "0.9.0"
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 [dependencies]
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
+serde-aux = "3.1.0"
 serde_json = "1.0"
 thiserror = "1.0"
 tungstenite = { version = "0.15.0", features = ["native-tls"] }

--- a/examples/inverse_private_ws_api_client.rs
+++ b/examples/inverse_private_ws_api_client.rs
@@ -15,11 +15,11 @@ fn main() {
     client.subscribe_wallet();
 
     let callback = |res: PrivateResponse| match res {
-        PrivateResponse::Position(res) => println!("Position: {:?}", res),
-        PrivateResponse::Execution(res) => println!("Execution: {:?}", res),
-        PrivateResponse::Order(res) => println!("Order: {:?}", res),
-        PrivateResponse::StopOrder(res) => println!("Stop Order: {:?}", res),
-        PrivateResponse::Wallet(res) => println!("Wallet: {:?}", res),
+        PrivateResponse::PositionMessage(res) => println!("Position: {:?}", res),
+        PrivateResponse::ExecutionMessage(res) => println!("Execution: {:?}", res),
+        PrivateResponse::OrderMessage(res) => println!("Order: {:?}", res),
+        PrivateResponse::StopOrderMessage(res) => println!("Stop Order: {:?}", res),
+        PrivateResponse::WalletMessage(res) => println!("Wallet: {:?}", res),
     };
 
     match client.run(callback) {

--- a/examples/inverse_public_ws_api_client.rs
+++ b/examples/inverse_public_ws_api_client.rs
@@ -15,24 +15,26 @@ fn main() {
     client.subscribe_liquidation(&symbols);
 
     let callback = |res: PublicResponse| match res {
-        PublicResponse::OrderBookL2Snapshot(res) => println!("Order book L2 snapshot: {:?}", res),
-        PublicResponse::OrderBookL2Delta(res) => println!("Order book L2 delta: {:?}", res),
-        PublicResponse::Trade(res) => println!("Trade: {:?}", res),
-        PublicResponse::Insurance(res) => println!("Insurance: {:?}", res),
-        PublicResponse::PerpetualInstrumentInfoSnapshot(res) => {
+        PublicResponse::OrderBookL2SnapshotMessage(res) => {
+            println!("Order book L2 snapshot: {:?}", res)
+        }
+        PublicResponse::OrderBookL2DeltaMessage(res) => println!("Order book L2 delta: {:?}", res),
+        PublicResponse::TradeMessage(res) => println!("Trade: {:?}", res),
+        PublicResponse::InsuranceMessage(res) => println!("Insurance: {:?}", res),
+        PublicResponse::PerpetualInstrumentInfoSnapshotMessage(res) => {
             println!("Perpetual instrument info snapshot: {:?}", res)
         }
-        PublicResponse::PerpetualInstrumentInfoDelta(res) => {
+        PublicResponse::PerpetualInstrumentInfoDeltaMessage(res) => {
             println!("Perpetual instrument info delta: {:?}", res)
         }
-        PublicResponse::FuturesInstrumentInfoSnapshot(res) => {
+        PublicResponse::FuturesInstrumentInfoSnapshotMessage(res) => {
             println!("Futures instrument info snapshot: {:?}", res)
         }
-        PublicResponse::FuturesInstrumentInfoDelta(res) => {
+        PublicResponse::FuturesInstrumentInfoDeltaMessage(res) => {
             println!("Futures instrument info delta: {:?}", res)
         }
-        PublicResponse::Kline(res) => println!("Kline: {:?}", res),
-        PublicResponse::Liquidation(res) => println!("Liquidation: {:?}", res),
+        PublicResponse::KlineMessage(res) => println!("Kline: {:?}", res),
+        PublicResponse::LiquidationMessage(res) => println!("Liquidation: {:?}", res),
     };
 
     match client.run(callback) {

--- a/src/inverse/ws.rs
+++ b/src/inverse/ws.rs
@@ -53,6 +53,36 @@ pub enum PositionSide {
     None,
 }
 
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+pub enum OrderStatus {
+    /// Order has been accepted by the system but not yet put through the matching engine.
+    Created,
+    /// Order has been placed successfully.
+    New,
+    Rejected,
+    PartiallyFilled,
+    Filled,
+    /// Matching engine has received the cancelation request but it may not be canceled successfully.
+    PendingCancel,
+    Cancelled,
+    /// Order yet to be triggered.
+    ///
+    /// Note: only applies to conditional orders.
+    Untriggered,
+    /// Order has been canceled by the user before being triggered
+    ///
+    /// Note: only applies to conditional orders.
+    Deactivated,
+    /// Order has been triggered by last traded price
+    ///
+    /// Note: only applies to conditional orders.
+    Triggered,
+    /// Order has been triggered and the new active order has been successfully placed. Is the final state of a successful conditional order
+    ///
+    /// Note: only applies to conditional orders.
+    Active,
+}
+
 #[derive(Debug, Deserialize)]
 pub struct Response<'a, D> {
     pub topic: &'a str,
@@ -739,7 +769,7 @@ pub struct Order<'a> {
     /// Trigger scenario for cancel operation
     pub cancel_type: &'a str,
     /// Order status
-    pub order_status: &'a str,
+    pub order_status: OrderStatus,
     /// Number of unfilled contracts from the order's size
     pub leaves_qty: u32,
     /// Cumulative qty of trading

--- a/tests/inverse_ws.rs
+++ b/tests/inverse_ws.rs
@@ -1,0 +1,299 @@
+use std::error::Error;
+
+use bybit::{
+    self,
+    inverse::ws::{
+        Execution, ExecutionMessage, Order, OrderMessage, OrderSide, Position, PositionMessage,
+        PositionSide, StopOrder, StopOrderMessage, Wallet, WalletMessage,
+    },
+};
+
+#[test]
+fn deserialize_position_message() -> Result<(), Box<dyn Error>> {
+    let message = r#"
+    {
+        "topic": "position",
+        "data": [{
+            "user_id": 12345,
+            "symbol": "ETHUSD",
+            "size": 0,
+            "side": "None",
+            "position_value": "0",
+            "entry_price": "0",
+            "liq_price": "0",
+            "bust_price": "0",
+            "leverage": "10",
+            "order_margin": "0.00008362",
+            "position_margin": "0",
+            "available_balance": "0.11003042",
+            "take_profit": "0",
+            "stop_loss": "0",
+            "realised_pnl": "0.00280582",
+            "trailing_stop": "0",
+            "trailing_active": "0",
+            "wallet_balance": "0.11011404",
+            "risk_id": 11,
+            "occ_closing_fee": "0",
+            "occ_funding_fee": "0",
+            "auto_add_margin": 1,
+            "cum_realised_pnl": "0.01511404",
+            "position_status": "Normal",
+            "position_seq": 0,
+            "Isolated": false,
+            "mode": 0,
+            "position_idx": 0,
+            "tp_sl_mode": "Full",
+            "tp_order_num": 0,
+            "sl_order_num": 0,
+            "tp_free_size_x": 0,
+            "sl_free_size_x": 0
+        }]
+    }
+    "#;
+
+    let expected: PositionMessage = PositionMessage {
+        topic: "position",
+        data: vec![Position {
+            user_id: 12345,
+            symbol: "ETHUSD",
+            size: 0,
+            side: PositionSide::None,
+            position_value: "0",
+            entry_price: "0",
+            liq_price: "0",
+            bust_price: "0",
+            leverage: "10",
+            order_margin: "0.00008362",
+            position_margin: "0",
+            available_balance: "0.11003042",
+            take_profit: "0",
+            stop_loss: "0",
+            realised_pnl: "0.00280582",
+            trailing_stop: "0",
+            trailing_active: "0",
+            wallet_balance: "0.11011404",
+            risk_id: 11,
+            occ_closing_fee: "0",
+            occ_funding_fee: "0",
+            auto_add_margin: 1,
+            cum_realised_pnl: "0.01511404",
+            position_status: "Normal",
+            position_seq: 0,
+            isolated: false,
+            mode: 0,
+            position_idx: 0,
+            tp_sl_mode: "Full",
+            tp_order_num: 0,
+            sl_order_num: 0,
+            tp_free_size_x: 0,
+            sl_free_size_x: 0,
+        }],
+    };
+
+    let actual: PositionMessage = serde_json::from_str(message)?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_execution_message() -> Result<(), Box<dyn Error>> {
+    let message = r#"
+    {
+        "topic": "execution",
+        "data": [{
+            "symbol": "ETHUSD",
+            "side": "Buy",
+            "order_id": "51d018c4-cda0-410d-8e37-0c7ea39aef8c",
+            "exec_id": "8b0e0dfa-dc2a-5cca-b11a-dc940d613954",
+            "order_link_id": "",
+            "price": "1219.8",
+            "order_qty": 1,
+            "exec_type": "Trade",
+            "exec_qty": 1,
+            "exec_fee": "0.0000005",
+            "leaves_qty": 0,
+            "is_maker": false,
+            "trade_time": "2022-07-09T21:17:25.693Z"
+        }]
+    }
+    "#;
+
+    let expected: ExecutionMessage = ExecutionMessage {
+        topic: "execution",
+        data: vec![Execution {
+            symbol: "ETHUSD",
+            side: OrderSide::Buy,
+            order_id: "51d018c4-cda0-410d-8e37-0c7ea39aef8c",
+            exec_id: "8b0e0dfa-dc2a-5cca-b11a-dc940d613954",
+            order_link_id: "",
+            price: 1219.8,
+            order_qty: 1,
+            exec_type: "Trade",
+            exec_qty: 1,
+            exec_fee: "0.0000005",
+            leaves_qty: 0,
+            is_maker: false,
+            trade_time: "2022-07-09T21:17:25.693Z",
+        }],
+    };
+
+    let actual: ExecutionMessage = serde_json::from_str(message)?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_order_message_message() -> Result<(), Box<dyn Error>> {
+    let message = r#"
+    {
+        "topic": "order",
+        "data": [{
+            "order_id": "310d02f7-4454-49b0-a467-eff609b00362",
+            "order_link_id": "",
+            "symbol": "ETHUSD",
+            "side": "Buy",
+            "order_type": "Limit",
+            "price": "1211",
+            "qty": 1,
+            "time_in_force": "PostOnly",
+            "create_type": "CreateByUser",
+            "cancel_type": "",
+            "order_status": "New",
+            "leaves_qty": 1,
+            "cum_exec_qty": 0,
+            "cum_exec_value": "0",
+            "cum_exec_fee": "0",
+            "timestamp": "2022-07-09T15:39:18.973Z",
+            "take_profit": "0",
+            "stop_loss": "0",
+            "trailing_stop": "0",
+            "last_exec_price": "0",
+            "reduce_only": false,
+            "close_on_trigger": false
+        }]
+    }
+    "#;
+
+    let expected: OrderMessage = OrderMessage {
+        topic: "order",
+        data: vec![Order {
+            order_id: "310d02f7-4454-49b0-a467-eff609b00362",
+            order_link_id: "",
+            symbol: "ETHUSD",
+            side: OrderSide::Buy,
+            order_type: "Limit",
+            price: 1211.,
+            qty: 1,
+            time_in_force: "PostOnly",
+            create_type: "CreateByUser",
+            cancel_type: "",
+            order_status: "New",
+            leaves_qty: 1,
+            cum_exec_qty: 0,
+            cum_exec_value: "0",
+            cum_exec_fee: "0",
+            timestamp: "2022-07-09T15:39:18.973Z",
+            take_profit: "0",
+            tp_trigger_by: None,
+            stop_loss: "0",
+            sl_trigger_by: None,
+            trailing_stop: "0",
+            last_exec_price: "0",
+            reduce_only: false,
+            close_on_trigger: false,
+        }],
+    };
+
+    let actual: OrderMessage = serde_json::from_str(message)?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_stop_order_message() -> Result<(), Box<dyn Error>> {
+    let message = r#"
+    {
+        "topic": "stop_order",
+        "data": [{
+            "order_id": "1362c33a-7194-4463-a58c-b674f3bd7f25",
+            "order_link_id": "",
+            "user_id": 28587642,
+            "symbol": "ETHUSD",
+            "side": "Buy",
+            "order_type": "Market",
+            "price": "0",
+            "qty": 1,
+            "time_in_force": "ImmediateOrCancel",
+            "create_type": "CreateByStopLoss",
+            "cancel_type": "",
+            "order_status": "Untriggered",
+            "stop_order_type": "StopLoss",
+            "trigger_by": "LastPrice",
+            "trigger_price": "1225.75",
+            "timestamp": "2022-07-09T21: 17: 15.353Z",
+            "close_on_trigger": true
+        }]
+    }
+    "#;
+
+    let expected: StopOrderMessage = StopOrderMessage {
+        topic: "stop_order",
+        data: vec![StopOrder {
+            order_id: "1362c33a-7194-4463-a58c-b674f3bd7f25",
+            order_link_id: "",
+            user_id: 28587642,
+            symbol: "ETHUSD",
+            side: OrderSide::Buy,
+            order_type: "Market",
+            price: "0",
+            qty: 1,
+            time_in_force: "ImmediateOrCancel",
+            create_type: "CreateByStopLoss",
+            cancel_type: "",
+            order_status: "Untriggered",
+            stop_order_type: "StopLoss",
+            trigger_by: "LastPrice",
+            trigger_price: "1225.75",
+            timestamp: "2022-07-09T21: 17: 15.353Z",
+            close_on_trigger: true,
+        }],
+    };
+
+    let actual: StopOrderMessage = serde_json::from_str(message)?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}
+
+#[test]
+fn deserialize_wallet_message() -> Result<(), Box<dyn Error>> {
+    let message = r#"
+    {
+        "topic": "wallet",
+        "data": [{
+            "user_id": 12345,
+            "coin": "ETH",
+            "wallet_balance": "0.11011404",
+            "available_balance": "0.11003042"
+        }]
+    }
+    "#;
+
+    let expected: WalletMessage = WalletMessage {
+        topic: "wallet",
+        data: vec![Wallet {
+            user_id: 12345,
+            coin: "ETH",
+            wallet_balance: 0.11011404,
+            available_balance: 0.11003042,
+        }],
+    };
+
+    let actual: WalletMessage = serde_json::from_str(message)?;
+    assert_eq!(actual, expected);
+
+    Ok(())
+}


### PR DESCRIPTION
> This PR is based on #6 and #7

Hi! I'm opening this PR as a draft so I can get some early feedback; I've started taking the inverse websocket in a different direction than the spot/linear implementations and wanted to sync with you on this before it went too far off in the weeds. I'm not sure if some of these changes uphold the goals or direction you want to take this project, so I thought I'd ask!

I started consuming the inverse websocket library from an application I'm writing and these changes were helpful in keeping the consuming code readable and fun:

- exporting the type of an enum variant (I'm not sure if these words make sense, hopefully I'm close)
  This allows me to write a function expecting data from a particular response message

  ```rust
    pub fn initialize_from_snapshot(&mut self, snapshot_message: &OrderBookL2SnapshotMessage) {
        for rung in snapshot_message.data.iter() {
            self.insert_bybit_rung(rung);
        }
    }
  ```

  Well... now that I say this, I should probably just pass `&Vec<OrderBookItem>` and `&OrderBookDelta` (both already exported). Maybe this case is no longer as important to support, but it did bring the next point to my attention
- create a distinction between the response or message and the contained data
  For example, we had 

  ```rust
  pub struct BaseResponse<'a, D> {
      pub topic: &'a str,
      pub data: D,
  }

  pub enum PublicResponse<'a> {
      #[serde(borrow)]
      Trade(BaseResponse<Vec<Trade>>),
      // ...
  }
  ```

  This naturally had me thinking of the entire `BaseResponse<Vec<Trade>>` as a `Trade` (the enum variant) which caused a bit of a jerk when I accessed the `data` which was a ... `Trade`. It seemed more natural to refer to the unedited response as a `TradeMessage` which contains a `Vec<Trade>`. This rename causes the callback to be a little more verbose but seems to increase clarity everywhere else.
- deserializing some raw websocket values into a different type
  This is the most questionable change, because if the project goal is to be as fast as possible, this may perform more work than is necessary in all cases. Also, there can be some precision issues when changing a string-of-a-number into a `f64`, but I'm not sure of any other, superior way of dealing with floats in Rust so I figure this conversion is sort of inevitable. 

  Rather than handling these conversions on the client's side, I moved this logic into the deserializer using a crate called `serde-aux`. I've started to deserialize `Side` into an enum as well, which makes the client's logic cleaner and lets me lean on the type system more.
- adding tests, currently only of deserialization logic
  I'm always a bit confused reading the serde documentation, so I wrote tests to prove the deserialization would work as I expected it to. I'm not sure yet how to test every part of this implementation but I'm excited to keep pushing for higher test coverage

That's about it, so I guess my goals for these diffs are
- leverage the type system to increase confidence about correctness and improve developer experience through "implementation by cases"
- provide a great developer experience by presenting information from Bybit's API in a way that minimizes wtfs-per-minute (Bybit leaves a lot of room for improvement here)

Thanks in advance!