### PR TITLE
spot builder api

### DIFF
--- a/examples/private_ws_api_client.rs
+++ b/examples/private_ws_api_client.rs
@@ -6,8 +6,9 @@ fn main() {
 
     let api_key: String = env::var("BYBIT_API_KEY").unwrap();
     let secret: String = env::var("BYBIT_SECRET").unwrap();
-    let client =
-        PrivateWebSocketApiClient::new("wss://stream-testnet.bybit.com/spot/ws", &api_key, &secret);
+    let client = PrivateWebSocketApiClient::builder()
+        .testnet()
+        .build_with_credentials(&api_key, &secret);
 
     let callback = |res: PrivateResponse| match res {
         PrivateResponse::ExecutionReportSequence(seq) => println!("Excution report: {:?}", seq),

--- a/examples/public_v2_ws_api_client.rs
+++ b/examples/public_v2_ws_api_client.rs
@@ -3,7 +3,7 @@ use bybit::spot::ws::{PublicV2Response, PublicV2WebSocketApiClient};
 fn main() {
     env_logger::init();
 
-    let mut client = PublicV2WebSocketApiClient::new("wss://stream.bybit.com/spot/quote/ws/v2");
+    let mut client = PublicV2WebSocketApiClient::new();
 
     client.subscribe_depth("BTCUSDT", false);
     client.subscribe_kline("BTCUSDT", false, "1m");

--- a/examples/public_ws_api_client.rs
+++ b/examples/public_ws_api_client.rs
@@ -3,7 +3,7 @@ use bybit::spot::ws::{PublicResponse, PublicWebSocketApiClient};
 fn main() {
     env_logger::init();
 
-    let mut client = PublicWebSocketApiClient::new("wss://stream.bybit.com/spot/quote/ws/v1");
+    let mut client = PublicWebSocketApiClient::new();
 
     client.subscribe_trade("BTCUSDT", false);
     client.subscribe_realtimes("BTCUSDT", false);

--- a/examples/spot_local_order_book.rs
+++ b/examples/spot_local_order_book.rs
@@ -4,7 +4,7 @@ use std::io::{self, Write};
 struct OwnedOrderBookItem(String, String);
 
 fn main() {
-    let mut client = PublicWebSocketApiClient::new("wss://stream.bybit.com/spot/quote/ws/v1");
+    let mut client = PublicWebSocketApiClient::new();
 
     client.subscribe_trade("BTCUSDT", false);
     client.subscribe_diff_depth("BTCUSDT", false);


### PR DESCRIPTION
Introduces builder api for conveniently creating `WebSocketApiClient` following Rust builder pattern.