### PR TITLE
ci: fix typo in toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,12 @@ jobs:
         triple:
           - {
               os: "ubuntu-latest",
-              target: "x86_64-unknown-linux",
+              target: "x86_64-unknown-linux-gnu",
               cross: false,
             }
           - {
               os: "ubuntu-latest",
-              target: "i686-unknown-linux",
+              target: "i686-unknown-linux-gnu",
               cross: true,
             }
           - {


### PR DESCRIPTION
I accidentally used `x86_64-unknown-linux` when the toolchain is
actually called `x86_64-unknown-linux-gnu`.