### PR TITLE
ci: disable 32-bit cargo check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,11 @@
 ---
 name: CI
 
-on: [ pull_request ]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 # This pipeline validates proposed changes.
 
@@ -19,11 +23,6 @@ jobs:
               os: "ubuntu-latest",
               target: "x86_64-unknown-linux-gnu",
               cross: false,
-            }
-          - {
-              os: "ubuntu-latest",
-              target: "i686-unknown-linux-gnu",
-              cross: true,
             }
           - {
               os: "macOS-latest",


### PR DESCRIPTION
Since this adds minimal value and we would need to wrangle openssl
headers on the CI runner.

Also, run CI on pushes to main.